### PR TITLE
Fix minor type in the argument in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Type the phenotype name
 OR  
 '1' selects first phenotype from phenotype file (second column), '2' the second phenotype (third column) and so on.
 
-* `-ap` / `--allphentypes`  
+* `-ap` / `--allphenotypes`  
 All phenotypes in the phenotype file will be used.
 
 * `-cf` / `--cfile` <filename>  


### PR DESCRIPTION
There's this minor typo in the argument where `--allphenotypes` is written as `allphenotypes`.