### PR TITLE
Enable User Selection Between Bonferroni and FDR Correction Methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,42 @@
 [![Anaconda-Server Badge](https://anaconda.org/fvogt257/vcf2gwas/badges/license.svg)](https://anaconda.org/fvogt257/vcf2gwas)
 [![Anaconda-Server Badge](https://anaconda.org/fvogt257/vcf2gwas/badges/installer/conda.svg)](https://conda.anaconda.org/fvogt257)
 [![Anaconda-Server Badge](https://anaconda.org/fvogt257/vcf2gwas/badges/platforms.svg)](https://anaconda.org/fvogt257/vcf2gwas)
+
+## July 2025 Update: Enable User Selection Between Bonferroni and FDR Correction Methods
+In its current version, `vcf2gwas` defaults to a Bonferroni correction, which tends to be quite conservative, especially for genome-wide association studies. This fork enhances the statistical flexibility of `vcf2gwas` by incorporating a new flag (`--correction` or `-cm`) to allow users to specify their preferred significance threshold, supporting both Bonferroni (default) and False Discovery Rate (FDR) corrections.
+
+### Summary of modifications
+To implement this feature, I made the following changes:
+1. Updated `meta.yaml` to include the `statsmodel` package, which is used to perform the FDR correction.
+2. Added a new flag `-cm/--correction` in the parsing.py script, allowing users to choose between Bonferroni and FDR correction methods. If unspecified, the default remains Bonferroni, preserving the original functionality of the program.
+3. Modified the `manh_plot` function in `utils.py` to implement the Benjamini-Hochberg (BH) procedure for FDR correction using `statsmodels`. Additionally, I added log statements to indicate which multiple testing correction method was applied.
+
+### Installation via Conda/Mamba
+
+1. Clone this forked repository to your desired machine and navigate to the project directory:
+```
+git clone https://github.com/AllysonDekovich/vcf2gwas.git
+cd vcf2gwas
+```
+
+2. Use the provided YAML file (located in the `conda.recipe` folder) to create a Conda/Mamba environment. This file contains all the necessary dependencies needed for the program.
+```
+mamba env create -f ./conda.recipe/vcf2gwas_cm.yaml
+```
+3. Activate the new environment and install the package in "editable" mode to ensure that the `vcf2gwas` command properly points to the modified source code.
+```
+mamba activate vcf2gwas_cm
+pip install -e .
+```
+4. Check to see if the installation worked:
+```
+vcf2gwas --help
+```
+This should now produce documentation for the new `--correction/-cm`
+
+
+
+
 ## Contents
 
 * [About The Project](#about-the-project)

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -34,6 +34,7 @@ requirements:
     - plink=1.90
     - plink2=2.0
     - gemma==0.98.3
+    - statsmodels=0.14.4
 
 test:
 

--- a/conda.recipe/vcf2gwas_cm.yaml
+++ b/conda.recipe/vcf2gwas_cm.yaml
@@ -19,5 +19,3 @@ dependencies:
   - gemma=0.98.3
   - statsmodels=0.14.4
   - pip
-  - pip:
-    - git+https://github.com/AllysonDekovich/vcf2gwas.git

--- a/conda.recipe/vcf2gwas_cm.yaml
+++ b/conda.recipe/vcf2gwas_cm.yaml
@@ -1,4 +1,4 @@
-name: vcf2gwas_custom
+name: vcf2gwas_cm
 channels:
   - conda-forge
   - bioconda

--- a/conda.recipe/vcf2gwas_cm.yaml
+++ b/conda.recipe/vcf2gwas_cm.yaml
@@ -1,0 +1,23 @@
+name: vcf2gwas_custom
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - python=3.9
+  - numpy=1.23
+  - pandas=1.5
+  - matplotlib=3.7
+  - seaborn=0.12
+  - scikit-allel=1.3
+  - scikit-learn=1.2
+  - psutil=5.9
+  - adjusttext=0.7
+  - bcftools=1.17
+  - plink=1.90
+  - plink2=2.0
+  - gemma=0.98.3
+  - statsmodels=0.14.4
+  - pip
+  - pip:
+    - git+https://github.com/AllysonDekovich/vcf2gwas.git

--- a/vcf2gwas/parsing.py
+++ b/vcf2gwas/parsing.py
@@ -131,6 +131,12 @@ def getArgs(argv=None):
         "-sv", "--sigval", metavar="<float>", type=float, 
         help="set value where to draw significant line in manhattan plot \n<int> represents -log10(1e-<int>) \ndefault: Bonferroni corrected with total amount of SNPs used for analysis \nset <int> to '0' to disable line"
     )
+      parser.add_argument(
+    "-cm", "--correction", metavar="<method>", choices=["bonferroni", "fdr"], default="bonferroni",
+    help=(
+    "Multiple testing correction method to use for significance threshold and corrected p-values\n"
+    "Options: 'bonferroni' (default) or 'fdr'")
+    )    
     parser.add_argument(
         "-w", "--burn", metavar="<int>", type=int, default=100000,
         help="specify burn-in steps when using BSLMM model \ndefault: %(default)s"


### PR DESCRIPTION
Hello,

I have been using your program for the past few weeks, and I just wanted to say how fantastic it is! It has made the entire GWAS workflow much more digestible and manageable, especially because I have previously struggled with formatting files correctly for GEMMA.

While using this tool, I came across one aspect that I thought could benefit from improvement. Currently, `vcf2gwas` defaults to a Bonferroni correction, which tends to be quite conservative, especially for genome-wide association studies. After running an association analysis on cuticle color variation in ants, no SNPs passed the Bonferroni threshold for significance (see below), which prompted me to look into more flexible alternatives.

![p_wald_manh_mean_RGB_head+mean_RGB_thorax_mod_sub_hybrids_parents_color_pheno_file_hybrid_parents_gwas_color_chrRename_onlychr_bonferroni](https://github.com/user-attachments/assets/8e1d9ced-d00e-49e3-8315-cbef4ab7405b)

I initially considered re-running the program with a pre-defined significance value (`--sigval`), but I preferred to use a statistically supported method for setting the threshold. With that in mind, I opted to apply a false discovery rate (FDR) correction to determine signficance.

Summary of modifications:
To implement this feature, I made the following changes:
1. Updated `meta.yaml` to include the `statsmodels` package, which is used to perform the FDR correction.
2. Added a new flag `-cm/--correction` in the `parsing.py` script, allowing users to choose between Bonferroni and FDR correction methods. If unspecified, the default remains Bonferroni, preserving the original functionality of the program.
3. Modified the `manh_plot` function in the `utils.py` script to implement the Benjamini-Hochberg (BH) procedure for FDR correction using `statsmodels`. Additionally, I added log statements to indicate which multiple testing correction method was applied.

I tested these modifications using my own dataset. Previously, using Bonferroni correction yielded no significant SNPs, but with the new FDR method, 381 significant SNPs were identified.

![p_wald_manh_mean_RGB_head+mean_RGB_thorax_mod_sub_hybrids_parents_color_pheno_file_hybrid_parents_gwas_color_chrRename_onlychr_FDR](https://github.com/user-attachments/assets/70aaf442-1cc8-48b2-a1b2-8ef32a6b86c6)

Let me know your thoughts. I'd be happy to collaborate further to help integrate this functionality into the main program!


